### PR TITLE
Pin composer version to ~1 for now to ensure builds

### DIFF
--- a/composer-installer.sh
+++ b/composer-installer.sh
@@ -11,7 +11,7 @@ then
     exit 1
 fi
 
-php composer-setup.php --quiet
+php composer-setup.php --quiet --version=~1
 RESULT=$?
 rm composer-setup.php
 exit $RESULT


### PR DESCRIPTION
Docker building was broken by Composer v 2 (presstisimo not needed, psalm ~1 dependencies broken) 
Tanks to @diazdavid-info for the report